### PR TITLE
Added BookView & CategoryView

### DIFF
--- a/digestapi/fixtures/books.json
+++ b/digestapi/fixtures/books.json
@@ -1,0 +1,50 @@
+[
+    {
+        "model": "digestapi.book",
+        "pk": 1,
+        "fields": {
+            "user": 1,
+            "title": "The Neverending Story",
+            "author": "Edwin R. Billows",
+            "isbn_number": "8573282904",
+            "cover_image": "https://m.media-amazon.com/images/I/51lk9sIp1YL.jpg",
+            "categories": [3, 4]
+        }
+    },
+    {
+        "model": "digestapi.book",
+        "pk": 2,
+        "fields": {
+            "user": 1,
+            "title": "The Catcher in the Rye",
+            "author": "J.D. Salinger",
+            "isbn_number": "0316769177",
+            "cover_image": "https://i.etsystatic.com/20545894/r/il/6ff9d9/1977098755/il_570xN.1977098755_7szr.jpg",
+            "categories": [1, 4]
+        }
+    },
+    {
+        "model": "digestapi.book",
+        "pk": 3,
+        "fields": {
+            "user": 2,
+            "title": "To Kill a Mockingbird",
+            "author": "Harper Lee",
+            "isbn_number": "0061120081",
+            "cover_image": "https://images.csmonitor.com/csm/2014/07/mockingbird.png?alias=standard_900x600",
+            "categories": [1, 4]
+        }
+    },
+    {
+        "model": "digestapi.book",
+        "pk": 4,
+        "fields": {
+            "user": 2,
+            "title": "1984",
+            "author": "George Orwell",
+            "isbn_number": "0451524934",
+            "cover_image": "https://librarycatalog.cityofwoodland.org/bookcover.php?id=ils%3A.b18977054&size=large&format=Book&isn=0451524934",
+            "categories": [1, 4, 5]
+        }
+    }
+]

--- a/digestapi/fixtures/categories.json
+++ b/digestapi/fixtures/categories.json
@@ -1,0 +1,37 @@
+[
+    {
+        "model": "digestapi.category",
+            "pk": 1,
+            "fields": {
+                "name": "Fiction"
+            }
+    },
+    {
+        "model": "digestapi.category",
+            "pk": 2,
+            "fields": {
+                "name": "Non-fiction"
+            }
+    },
+    {
+        "model": "digestapi.category",
+            "pk": 3,
+            "fields": {
+                "name": "fantasy"
+            }
+    },
+    {
+        "model": "digestapi.category",
+            "pk": 4,
+            "fields": {
+                "name": "classic literature"
+            }
+    },
+    {
+        "model": "digestapi.category",
+            "pk": 5,
+            "fields": {
+                "name": "science fiction"
+            }
+    }
+]

--- a/digestapi/models/__init__.py
+++ b/digestapi/models/__init__.py
@@ -1,5 +1,4 @@
 from .book import Book
 from .category import Category
 from .book_category import BookCategory
-from .user import User
 from .review import Review

--- a/digestapi/models/user.py
+++ b/digestapi/models/user.py
@@ -1,8 +1,0 @@
-from django.db import models
-
-class User(models.Model):
-    """Database model for tracking users"""
-
-    first_name = models.CharField(max_length=155)
-    last_name = models.CharField(max_length=155)
-    email = models.CharField(max_length=155)

--- a/digestapi/views/__init__.py
+++ b/digestapi/views/__init__.py
@@ -1,1 +1,3 @@
 from .users import UserViewSet
+from .books import BookViewSet
+from .categories import CategoryViewSet

--- a/digestapi/views/books.py
+++ b/digestapi/views/books.py
@@ -1,0 +1,115 @@
+from rest_framework import viewsets, status
+from rest_framework.response import Response
+from rest_framework import serializers
+from digestapi.models import Book
+from .categories import CategorySerializer
+
+
+class BookSerializer(serializers.ModelSerializer):
+    # Override default serialization to replace foreign keys
+    # with expanded related resource. By default, this would
+    # be a list of integers (e.g. [2, 4, 9]).
+    categories = CategorySerializer(many=True)
+
+    # Declare that an ad-hoc property should be included in JSON
+    is_owner = serializers.SerializerMethodField()
+
+    # Function containing instructions for ad-hoc property
+    def get_is_owner(self, obj):
+        # Check if the authenticated user is the owner
+        return self.context["request"].user == obj.user
+
+    class Meta:
+        model = Book
+        fields = [
+            "id",
+            "title",
+            "author",
+            "isbn_number",
+            "cover_image",
+            "is_owner",
+            "categories",
+        ]
+
+
+class BookViewSet(viewsets.ViewSet):
+    def list(self, request):
+        books = Book.objects.all()
+        serializer = BookSerializer(
+            books,
+            many=True,
+            context={"request": request},  # Allow serializer to access request
+        )
+        return Response(serializer.data)
+
+    def retrieve(self, request, pk=None):
+        try:
+            book = Book.objects.get(pk=pk)
+            serializer = BookSerializer(book, context={"request": request})
+            return Response(serializer.data)
+
+        except Book.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+    def create(self, request):
+        # Get the data from the client's JSON payload
+        title = request.data.get("title")
+        author = request.data.get("author")
+        isbn_number = request.data.get("isbn_number")
+        cover_image = request.data.get("cover_image")
+
+        # Create a book database row first, so you have a
+        # primary key to work with
+        book = Book.objects.create(
+            user=request.user,
+            title=title,
+            author=author,
+            cover_image=cover_image,
+            isbn_number=isbn_number,
+        )
+
+        # Establish the many-to-many relationships
+        # Get the list of [3, 5] from the request payload
+        category_ids = request.data.get("categories", [])
+        # Assign categories 3 and 5 to the new book 12 with one line of code
+        book.categories.set(category_ids)
+
+        serializer = BookSerializer(book, context={"request": request})
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    def update(self, request, pk=None):
+        try:
+            book = Book.objects.get(pk=pk)
+
+            # Is the authenticated user allowed to edit this book?
+            self.check_object_permissions(request, book)
+
+            serializer = BookSerializer(data=request.data)
+            if serializer.is_valid():
+                book.title = serializer.validated_data["title"]
+                book.author = serializer.validated_data["author"]
+                book.isbn_number = serializer.validated_data["isbn_number"]
+                book.cover_image = serializer.validated_data["cover_image"]
+                book.save()
+
+                category_ids = request.data.get("categories", [])
+                book.categories.set(category_ids)
+
+                serializer = BookSerializer(book, context={"request": request})
+                return Response(None, status.HTTP_204_NO_CONTENT)
+
+            return Response(serializer.errors, status.HTTP_400_BAD_REQUEST)
+
+        except Book.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+    def destroy(self, request, pk=None):
+        try:
+            book = Book.objects.get(pk=pk)
+            self.check_object_permissions(request, book)
+            book.delete()
+
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+        except Book.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)

--- a/digestapi/views/categories.py
+++ b/digestapi/views/categories.py
@@ -1,0 +1,25 @@
+from rest_framework import viewsets, status
+from rest_framework import serializers
+from rest_framework.response import Response
+from digestapi.models import Category
+
+
+class CategorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Category
+        fields = ["id", "name"]
+
+
+class CategoryViewSet(viewsets.ViewSet):
+    def list(self, request):
+        categories = Category.objects.all()
+        serializer = CategorySerializer(categories, many=True)
+        return Response(serializer.data)
+
+    def retrieve(self, request, pk=None):
+        try:
+            category = Category.objects.get(pk=pk)
+            serializer = CategorySerializer(category)
+            return Response(serializer.data)
+        except Category.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)

--- a/digestproject/urls.py
+++ b/digestproject/urls.py
@@ -1,12 +1,16 @@
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
-from digestapi.views import UserViewSet
+from digestapi.views import UserViewSet, BookViewSet, CategoryViewSet
 
 router = DefaultRouter(trailing_slash=False)
+router.register(r"books", BookViewSet, "book")
+router.register(r"categories", CategoryViewSet, "category")
 
 urlpatterns = [
-    path('', include(router.urls)),
-    path('login', UserViewSet.as_view({'post': 'user_login'}), name='login'),
-    path('register', UserViewSet.as_view({'post': 'register_account'}), name='register'),
+    path("", include(router.urls)),
+    path("login", UserViewSet.as_view({"post": "user_login"}), name="login"),
+    path(
+        "register", UserViewSet.as_view({"post": "register_account"}), name="register"
+    ),
 ]


### PR DESCRIPTION
I added a book view and a category view and update the routes for both.

Supported routes
`/books` allows a POST to register a new user that returns a token
`/categories` allows a POST to login which returns the same token they received upon registering

## Steps to test
### Books
1. Pull down the `book_requests` branch and switch to it
2. If your debugger is running, restart it
3. Open Postman
4. Request `http://localhost:8000/books` and it should return a list of objects with the following keys:
```
{
        "id": 1,
        "title": "The Neverending Story",
        "author": "Edwin R. Billows",
        "isbn_number": "8573282904",
        "cover_image": "https://m.media-amazon.com/images/I/51lk9sIp1YL.jpg",
        "is_owner": true,
        "categories": [
            {
                "id": 3,
                "name": "fantasy"
            },
            {
                "id": 4,
                "name": "classic literature"
            }
        ]
    }
```

5. Be sure you receive a 200 status code

### Categories
1. Request `http://localhost:8000/categories` and it should return a list of objects with the following keys:
```
{
        "id": 1,
        "name": "Fiction"
}
```
2. Be sure you receive a 200 status code